### PR TITLE
Added Emoji Movie Entry

### DIFF
--- a/data.js
+++ b/data.js
@@ -486,7 +486,16 @@ const emojiItems = [
         type: "movie",
         year: 2000,
         itemLink: "https://www.imdb.com/title/tt0242423/"
-    },{
+    },
+    {
+	title: "The Emoji Movie",
+        emojiImgs: "😀😒✋💩",
+        genres: ["animation", "adventure", "comedy"],
+	itemLink: "https://www.imdb.com/title/tt4877122/",
+        type: "movie",
+        year: 2017
+    },
+    {
         title: "Eragon",
         emojiImgs: "👦🏼🐉🥚⚔️👑",
         genres: ["action", "adventure", "family"],
@@ -1649,14 +1658,6 @@ const emojiItems = [
         type: "movie",
         year: 1990
     },
-    {
-	title: "The Emoji Movie",
-        emojiImgs: "😀😒✋💩",
-        genres: ["animation", "adventure", "comedy"],
-	itemLink: "https://www.imdb.com/title/tt4877122/",
-        type: "movie",
-        year: 2017
-    },    
     {
         title: "Their Eyes Were Watching God",
         emojiImgs: "👀👼🎬",

--- a/data.js
+++ b/data.js
@@ -1650,6 +1650,14 @@ const emojiItems = [
         year: 1990
     },
     {
+	title: "The Emoji Movie",
+        emojiImgs: "😀😒✋💩",
+        genres: ["animation", "adventure", "comedy"],
+	itemLink: "https://www.imdb.com/title/tt4877122/",
+        type: "movie",
+        year: 2017
+    },    
+    {
         title: "Their Eyes Were Watching God",
         emojiImgs: "👀👼🎬",
         genres: ["drama", "romance"],


### PR DESCRIPTION
<!-- You must fill out this to do list for your pull request to be accepted.  If you are adding a new TV show, movie or musical, please follow the checklist below. Place an [x] (get rid of any spaces) inside each square as you complete each item. This is just to help you double check for any errors that might come up. 🙂 If this pull request is to address something other than adding shows or movies, please delete the text below and write your own description on what you have changed/added to the project. -->

- [x] 🔍 I have searched the `data.js` file and confirmed I am not adding a duplicate entry. Note: Different versions of the same show/movie are okay to add such as Lion King (1994) and Lion King (2019) or Rent (movie) and Rent (musical).
- [ x] 💜 I have checked Issues and Pull Requests to confirm I am not adding a duplicate entry that is pending approval.
- [ x] 🌈 I have added a single year under `year`. Note: Do not add ranges such as 2017-2019.
- [x ] 📅 I have added a type from one of the following: `movie` , `tv` or `musical`.
- [x ] 🔗 I have added the IMDB page or Playbill archive page under `itemLink`.
- [x ] 3️⃣ I have at least three emojis listed under `emojiImgs`.
- [x ] 5️⃣ I have a maximum of five emojis listed under `emojiImgs`.
- [ x] 👍 My pull request has a descriptive title (such as `Added The Lion King` or `Added Black Panther, The Avengers: Endgame and Thor`).
- [ x] ⭐ My genres are all inside of square brackets `[ ]` and each are individually wrapped in quotation marks and have a comma between each one. (such as submitting this `"genres": ["adventure","mystery","animation"]` and not this `"genres":["adventure, mystery, animation"]`).
- [x ] 🖍️ I have placed the new show(s) or movie(s) in alphabetical order based on title. If the show or movie starts with 'the', then use the second word to alphabetize.

<!-- 👋 If this pull request closes an issue, add Closes #--- to the bottom of the pull request (replace the --- with the issue number). -->

Closes #528 
