### PR TITLE
citizen kane and the jungle book added

### DIFF
--- a/data.js
+++ b/data.js
@@ -531,6 +531,14 @@ const emojiItems = [
     itemLink: "https://www.imdb.com/title/tt0042332/"
   },
   {
+    title: "Citizen Kane",
+    emojiImgs:"🌹🛷📰🗞️",
+    genres:["drama", "mystery", "classic"],
+    type:"movie",
+    year: 1941,
+    itemLink:"https://www.imdb.com/title/tt0033467/"
+  },
+  {
     title: "Cloudy with a Chance of Meatballs",
     emojiImgs: " ☁️🥩⚽☂️",
     genres: ["animation", "adventure", "comedy"],
@@ -1330,6 +1338,15 @@ const emojiItems = [
       itemLink: "https://www.imdb.com/title/tt6146586/",
       type: "movie",
       year: 2019
+  },
+  {
+    title:"The Jungle Book",
+    emojiImgs:"🐻🐯🐍🐵📖",
+    genres:["adventure", "drama", "family"],
+    itemlink: "https://www.imdb.com/title/tt3040964/",
+    type: "movie",
+    year: 2016
+
   },
   {
       title: "Jurassic Park",

--- a/data.js
+++ b/data.js
@@ -1346,7 +1346,6 @@ const emojiItems = [
     itemlink: "https://www.imdb.com/title/tt3040964/",
     type: "movie",
     year: 2016
-
   },
   {
       title: "Jurassic Park",

--- a/data.js
+++ b/data.js
@@ -1343,7 +1343,7 @@ const emojiItems = [
     title:"The Jungle Book",
     emojiImgs:"🐻🐯🐍🐵📖",
     genres:["adventure", "drama", "family"],
-    itemlink: "https://www.imdb.com/title/tt3040964/",
+    itemLink: "https://www.imdb.com/title/tt3040964/",
     type: "movie",
     year: 2016
   },


### PR DESCRIPTION
Add movies from Rotten Tomatoes Top 100 Rated Movies .

Added to the data.js file. Even put them in correct alpha order.

1. J
The Jungle Book (2016) - though would/could work for all the other versions of this movie .
    title:"The Jungle Book",
    emojiImgs:"🐻🐯🐍🐵📖",
    genres:["adventure", "drama", "family"],
    itemlink: "https://www.imdb.com/title/tt3040964/",
    type: "movie",
    year: 2016

2. C
Citizen Kane (1941)
    title: "Citizen Kane",
    emojiImgs:"🌹🛷📰🗞️",
    genres:["drama", "mystery", "classic"],
    type:"movie",
    year: 1941,
    itemLink:"https://www.imdb.com/title/tt0033467/"