### PR TITLE
Fix: Added missing links for musicals #768

### DIFF
--- a/data/musicals.js
+++ b/data/musicals.js
@@ -44,7 +44,9 @@ const emojiMusicals = [
     emojiImgs: "💌⚰️👨‍👩‍👧‍👦💻💞",
     genres: ["drama", "musical"],
     type: "musical",
-    year: 2015
+    year: 2015,
+    itemLink:
+      "https://playbill.com/production/dear-evan-hansenmusic-box-theatre-2016-2017"
   }, {
     title: "Firebringer",
     emojiImgs: "🦆🕊️⚔️🔥👽",
@@ -57,14 +59,18 @@ const emojiMusicals = [
     emojiImgs: "☮🎶🇻🇳🇺🇸⚰ ",
     genres: ["comedy", "drama", "musical"],
     type: "musical",
-    year: 1979
+    year: 1979,
+    itemLink:
+      "https://playbill.com/production/hair-biltmore-theatre-vault-0000001544"
   },
   {
     title: "Hamilton: The Musical",
     emojiImgs: "💵🖋️⚖️🎵📜",
     genres: ["drama", "comedy", "musical"],
     type: "musical",
-    year: 2015
+    year: 2015,
+    itemLink:
+      "https://playbill.com/production/hamilton-richard-rodgers-theatre-vault-0000014104"
   }, {
     title: "Into the Woods",
     emojiImgs: "🔥🎄🎶👩‍🎤",
@@ -142,20 +148,26 @@ const emojiMusicals = [
     emojiImgs: "💈🔪☠️🍰",
     genres: ["drama", "horror", "musical"],
     type: "musical",
-    year: 1979
+    year: 1979,
+    itemLink:
+      "https://playbill.com/production/sweeney-todd-broadway-lunt-fontanne-theatre-2023"
   },
   {
     title: "West Side Story",
     emojiImgs: "🗽✈️⚔️🦈💔",
     genres: ["musical", "romance", "drama", "crime"],
     type: "musical",
-    year: 1961
+    year: 1961,
+    itemLink:
+      "https://playbill.com/production/west-side-story-winter-garden-theatre-vault-0000012293"
   },
   {
     title: "Wicked",
     emojiImgs: "💚🧹🧙‍♂️",
     genres: ["fantasy"],
     type: "musical",
-    year: 2003
+    year: 2003,
+    itemLink:
+      "https://playbill.com/production/wicked-george-gershwin-theatre-vault-0000011020"
   }
 ];


### PR DESCRIPTION
# Card Pull Request Checklist

Follow the checklist below when working on adding a card. This will help you double-check that you have everything you need to have your Pull Request approved. Add an `x` inside of the `[ ]` to check off an item like this `[x]`. You may delete this checklist if you are adding a feature to the project. 

During Hacktoberfest to decrease the number of PRs to approve, we will only be merging one PR adding cards per person. If you would like to add multiple shows or movies, please include them in one PR. 

- [X] 👍🏾 You have checked the [Issues](https://github.com/brittanyrw/emojiscreen/issues?q=is%3Aopen+is%3Aissue+label%3A%22add+emojis%22) and have gotten approval to add a movie or show to the project.
- [X] 🔎 Have searched the `movies.js`, `musicals.js` or `tv.js` files in the `data` folder and `Pull Requests` to make sure that you are not adding a duplicate.
- [X] 🖍️ Place the new show(s) or movie(s) in alphabetical order based on title. If the show or movie starts with 'the', then use the second word to alphabetize.
- [X] 🌈 There is a single year under `year`. 
- [X] 📅 There is a type from one of the following: `movie` , `tv` or `musical`.
- [X] 🔗 There is a link to the IMDB page or Playbill archive page under `itemLink`. If the movie or TV show is not on IMDB, please choose a different movie or TV show.
- [X] 3️⃣ There are at least three emojis listed under `emojiImgs`.
- [X] 5️⃣ There is a maximum of five emojis listed under `emojiImgs`.
- [X] 👍🏽 The pull request has a descriptive title (such as `Added The Lion King` or `Added Black Panther, The Avengers: Endgame and Thor`).
- [X] ⭐ The genres are all inside of square brackets `[ ]` and each are individually wrapped in quotation marks and have a comma between each one. (such as submitting this `"genres": ["adventure","mystery","animation"]` and not this `"genres":["adventure, mystery, animation"]`).
