### PR TITLE
Fix : Converted hint hover code from jQuery to JavaScript #772

### DIFF
--- a/app.js
+++ b/app.js
@@ -115,15 +115,19 @@ $(document).ready(function() {
   });
 
   // Display a hint (type ie tv, movie or musical) when hovering over the question mark.
-  $("#emojis").on("mouseover", ".hint-container", function () {
-    $(this).find(".hint").addClass("hint-reveal");
-  });
+  // Add an event listener to the parent element of the hint (assuming #emojis is the parent element).
+var emojisContainer = document.getElementById("emojis");
 
-  // Hide hint (type ie tv, movie or musical) when the user stops hovering over the question mark.
-  $("#emojis").on("mouseleave", ".hint-container", function () {
-    $(this).find(".hint").removeClass("hint-reveal");
-  });
-
+emojisContainer.addEventListener("mouseover", function(event) {
+  // Check if the event target has the class "hint-container."
+  if (event.target && event.target.classList.contains("hint-container")) {
+    // Find the ".hint" element within the event target and add the "hint-reveal" class.
+    var hintElement = event.target.querySelector(".hint");
+    if (hintElement) {
+      hintElement.classList.add("hint-reveal");
+    }
+  }
+});
   // Toggle to expand or hide all of the movie/show names by clicking an icon
   $(".btn-reveal-all").click(function () {
     $(this).toggleClass(["revealed"]);


### PR DESCRIPTION
# Card Pull Request Checklist

Follow the checklist below when working on adding a card. This will help you double-check that you have everything you need to have your Pull Request approved. Add an `x` inside of the `[ ]` to check off an item like this `[x]`. You may delete this checklist if you are adding a feature to the project. 

During Hacktoberfest to decrease the number of PRs to approve, we will only be merging one PR adding cards per person. If you would like to add multiple shows or movies, please include them in one PR. 

- [x] 👍🏾 You have checked the [Issues](https://github.com/brittanyrw/emojiscreen/issues?q=is%3Aopen+is%3Aissue+label%3A%22add+emojis%22) and have gotten approval to add a movie or show to the project.
- [x] 🔎 Have searched the `movies.js`, `musicals.js` or `tv.js` files in the `data` folder and `Pull Requests` to make sure that you are not adding a duplicate.
- [x] 🖍️ Place the new show(s) or movie(s) in alphabetical order based on title. If the show or movie starts with 'the', then use the second word to alphabetize.
- [x] 🌈 There is a single year under `year`. 
- [x] 📅 There is a type from one of the following: `movie` , `tv` or `musical`.
- [x] 🔗 There is a link to the IMDB page or Playbill archive page under `itemLink`. If the movie or TV show is not on IMDB, please choose a different movie or TV show.
- [x] 3️⃣ There are at least three emojis listed under `emojiImgs`.
- [x] 5️⃣ There is a maximum of five emojis listed under `emojiImgs`.
- [x] 👍🏽 The pull request has a descriptive title (such as `Added The Lion King` or `Added Black Panther, The Avengers: Endgame and Thor`).
- [x] ⭐ The genres are all inside of square brackets `[ ]` and each are individually wrapped in quotation marks and have a comma between each one. (such as submitting this `"genres": ["adventure","mystery","animation"]` and not this `"genres":["adventure, mystery, animation"]`).
